### PR TITLE
fix circular include in `UIContext.h`

### DIFF
--- a/src/ui/UIContext.h
+++ b/src/ui/UIContext.h
@@ -13,7 +13,6 @@
 #include "../components/SegmentedControl.h"
 #include "../components/Sidebar.h"
 #include "../components/Slider.h"
-#include "../components/ListView.h"
 #include <memory>
 #include <string>
 #include <type_traits>


### PR DESCRIPTION
Because of the circular include in `UIContext.h`, the code cannot compile with clang.

```bash
$ clang --version
clang version 21.1.8 (Fedora 21.1.8-4.fc43)
Target: x86_64-redhat-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
Configuration file: /etc/clang/x86_64-redhat-linux-gnu-clang.cfg

$ cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++

... omitting lines ...

$ cmake --build build

... omitting lines ...

[60/68] Building CXX object CMakeFiles/app_calculator_demo.dir/app/calculator_demo.cpp.o
FAILED: [code=1] CMakeFiles/app_calculator_demo.dir/app/calculator_demo.cpp.o 
/usr/bin/clang++  -I/home/nzd/repos/EUI/src -I/home/nzd/repos/EUI/third_party -I/home/nzd/repos/EUI/build/_deps/stb-src -I/home/nzd/repos/EUI/build/_deps/nanosvg-src/src -I/home/nzd/repos/EUI/build/_deps/glfw-src/include -I/home/nzd/repos/EUI/build/_deps/glad-src/include -O3 -DNDEBUG -std=gnu++17 -Os -fno-exceptions -fno-rtti -MD -MT CMakeFiles/app_calculator_demo.dir/app/calculator_demo.cpp.o -MF CMakeFiles/app_calculator_demo.dir/app/calculator_demo.cpp.o.d -o CMakeFiles/app_calculator_demo.dir/app/calculator_demo.cpp.o -c /home/nzd/repos/EUI/app/calculator_demo.cpp
In file included from /home/nzd/repos/EUI/app/calculator_demo.cpp:1:
In file included from /home/nzd/repos/EUI/src/app/DslAppRuntime.h:4:
In file included from /home/nzd/repos/EUI/src/app/../ui/UIContext.h:16:
/home/nzd/repos/EUI/src/app/../ui/../components/ListView.h:35:39: error: member access into incomplete type 'UIContext'
   35 |         const float scrollOffsetY = ui.pushScrollArea(id, x, y, width, height, contentHeight, scrollStep, RenderLayer::Chrome);
      |                                       ^
/home/nzd/repos/EUI/src/app/../ui/UIBuilder.h:10:7: note: forward declaration of 'EUINEO::UIContext'
   10 | class UIContext;
      |       ^
In file included from /home/nzd/repos/EUI/app/calculator_demo.cpp:1:
In file included from /home/nzd/repos/EUI/src/app/DslAppRuntime.h:4:
In file included from /home/nzd/repos/EUI/src/app/../ui/UIContext.h:16:
/home/nzd/repos/EUI/src/app/../ui/../components/ListView.h:60:11: error: member access into incomplete type 'UIContext'
   60 |         ui.popScrollArea();
      |           ^
/home/nzd/repos/EUI/src/app/../ui/UIBuilder.h:10:7: note: forward declaration of 'EUINEO::UIContext'
   10 | class UIContext;
      |       ^
2 errors generated.
[61/68] Building CXX object CMakeFiles/eui_neo_core.dir/src/EUINEO.cpp.o
ninja: build stopped: subcommand failed.
```